### PR TITLE
[ADD] Possiblity to filter vote tx and don't send them though RPC.

### DIFF
--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -246,6 +246,7 @@ pub struct RpcBlockConfig {
     pub encoding: Option<UiTransactionEncoding>,
     pub transaction_details: Option<TransactionDetails>,
     pub rewards: Option<bool>,
+    pub voting: Option<bool>,
     #[serde(flatten)]
     pub commitment: Option<CommitmentConfig>,
 }

--- a/client/src/rpc_deprecated_config.rs
+++ b/client/src/rpc_deprecated_config.rs
@@ -28,6 +28,7 @@ pub struct RpcConfirmedBlockConfig {
     pub encoding: Option<UiTransactionEncoding>,
     pub transaction_details: Option<TransactionDetails>,
     pub rewards: Option<bool>,
+    pub voting: Option<bool>,
     #[serde(flatten)]
     pub commitment: Option<CommitmentConfig>,
 }
@@ -70,6 +71,7 @@ impl From<RpcConfirmedBlockConfig> for RpcBlockConfig {
             encoding: config.encoding,
             transaction_details: config.transaction_details,
             rewards: config.rewards,
+            voting: config.voting,
             commitment: config.commitment,
         }
     }


### PR DESCRIPTION
This is done via a param that can be pass to get_block and remove the vote transactions.
